### PR TITLE
Update to GregTechCEu/Buildscripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,287 +1,408 @@
+//version: 1685492349
+/*
+ * DO NOT CHANGE THIS FILE!
+ * Also, you may replace this file at any time if there is an update available.
+ * Please check https://github.com/GregTechCEu/Buildscripts/blob/master/build.gradle for updates.
+ */
+
+import com.modrinth.minotaur.dependencies.ModDependency
+import com.modrinth.minotaur.dependencies.VersionDependency
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+import org.jetbrains.gradle.ext.Gradle
 
-buildscript {
-    repositories {
-        mavenCentral()
-        mavenLocal()
-        if (project.use_mixins.toBoolean()) {
-            maven {
-                name 'MixinGradle Maven'
-                url 'https://repo.spongepowered.org/repository/maven-public'
-            }
-        }
-    }
-    dependencies {
-        if (project.use_mixins.toBoolean()) {
-            classpath "org.spongepowered:mixingradle:${mixingradle_version}"
-        }
-    }
-}
+import static org.gradle.internal.logging.text.StyledTextOutput.Style
 
 plugins {
-    id 'net.minecraftforge.gradle' version "${forge_gradle_version}"
-    id 'wtf.gofancy.fancygradle' version "${fancy_gradle_version}"
+    id 'java'
+    id 'java-library'
+    id 'eclipse'
+    id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.7'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.+'
+    id 'net.darkhax.curseforgegradle' version '1.0.+' apply false
+    id 'com.modrinth.minotaur' version '2.7.+' apply false
+    id 'com.diffplug.spotless' version '6.13.0' apply false
+    id 'com.palantir.git-version' version '3.0.0' apply false
 }
 
-version = project.version
-group = project.maven_group
-archivesBaseName = "${project.archives_base_name}-${project.minecraft_version}"
+if (verifySettingsGradle()) {
+    throw new GradleException("Settings has been updated, please re-run task.")
+}
 
-java.toolchain.languageVersion = JavaLanguageVersion.of(8)
+def out = services.get(StyledTextOutputFactory).create('an-output')
 
-if (project.use_intellij_idea.toBoolean()) {
-    apply {
-        plugin 'java'
-        plugin 'idea'
+
+// Project properties
+
+// Required properties: we don't know how to handle these being missing gracefully
+checkPropertyExists("modName")
+checkPropertyExists("modId")
+checkPropertyExists("modGroup")
+checkPropertyExists("modVersion")
+checkPropertyExists("minecraftVersion") // hard-coding this makes it harder to immediately tell what version a mod is in (even though this only really supports 1.12.2)
+checkPropertyExists("apiPackage")
+checkPropertyExists("accessTransformersFile")
+checkPropertyExists("usesMixins")
+checkPropertyExists("mixinsPackage")
+checkPropertyExists("coreModClass")
+checkPropertyExists("containsMixinsAndOrCoreModOnly")
+
+// Optional properties: we can assume some default behavior if these are missing
+propertyDefaultIfUnset("autoUpdateBuildScript", false)
+propertyDefaultIfUnset("modArchivesBaseName", project.modId)
+propertyDefaultIfUnsetWithEnvVar("developmentEnvironmentUserName", "Developer", "DEV_USERNAME")
+propertyDefaultIfUnset("generateGradleTokenClass", "")
+propertyDefaultIfUnset("gradleTokenModId", "")
+propertyDefaultIfUnset("gradleTokenModName", "")
+propertyDefaultIfUnset("gradleTokenVersion", "")
+propertyDefaultIfUnset("includeWellKnownRepositories", true)
+propertyDefaultIfUnset("noPublishedSources", false)
+propertyDefaultIfUnset("forceEnableMixins", false)
+propertyDefaultIfUnset("modrinthProjectId", "")
+propertyDefaultIfUnset("modrinthRelations", "")
+propertyDefaultIfUnset("curseForgeProjectId", "")
+propertyDefaultIfUnset("curseForgeRelations", "")
+propertyDefaultIfUnset("releaseType", "release")
+propertyDefaultIfUnset("enableModernJavaSyntax", false)
+propertyDefaultIfUnset("enableSpotless", false)
+propertyDefaultIfUnset("enableJUnit", false)
+propertyDefaultIfUnsetWithEnvVar("deploymentDebug", false, "DEPLOYMENT_DEBUG")
+
+
+// Project property assertions
+
+final String javaSourceDir = 'src/main/java/'
+// If Scala or Kotlin are supported, add those paths here
+
+final String modGroupPath = modGroup.toString().replace('.' as char, '/' as char)
+final String apiPackagePath = apiPackage.toString().replace('.' as char, '/' as char)
+
+String targetPackageJava = javaSourceDir + modGroupPath
+// If Scala or Kotlin are supported, add those paths here
+
+if (!getFile(targetPackageJava).exists()) {
+    throw new GradleException("Could not resolve \"modGroup\"! Could not find " + targetPackageJava)
+}
+
+if (apiPackage) {
+    targetPackageJava = javaSourceDir + modGroupPath + '/' + apiPackagePath
+    if (!getFile(targetPackageJava).exists()) {
+        throw new GradleException("Could not resolve \"apiPackage\"! Could not find " + targetPackageJava)
     }
+}
 
-    idea {
-        module {
-            downloadJavadoc = true
-            downloadSources = true
+if (accessTransformersFile) {
+    for (atFile in accessTransformersFile.split(",")) {
+        String targetFile = 'src/main/resources/' + atFile.trim()
+        if (!getFile(targetFile).exists()) {
+            throw new GradleException("Could not resolve \"accessTransformersFile\"! Could not find " + targetFile)
+        }
+        tasks.deobfuscateMergedJarToSrg.accessTransformerFiles.from(targetFile)
+        tasks.srgifyBinpatchedJar.accessTransformerFiles.from(targetFile)
+    }
+}
+
+if (usesMixins.toBoolean()) {
+    if (mixinsPackage.isEmpty()) {
+        throw new GradleException("\"usesMixins\" requires \"mixinsPackage\" to be set!")
+    }
+    final String mixinPackagePath = mixinsPackage.toString().replaceAll('\\.', '/')
+    targetPackageJava = javaSourceDir + modGroupPath + '/' + mixinPackagePath
+    if (!getFile(targetPackageJava).exists()) {
+        throw new GradleException("Could not resolve \"mixinsPackage\"! Could not find " + targetPackageJava)
+    }
+}
+
+if (coreModClass) {
+    final String coreModPath = coreModClass.toString().replaceAll('\\.', '/')
+    String targetFileJava = javaSourceDir + modGroupPath + '/' + coreModPath + '.java'
+    if (!getFile(targetFileJava).exists()) {
+        throw new GradleException("Could not resolve \"coreModClass\"! Could not find " + targetFileJava)
+    }
+}
+
+
+// Plugin application
+
+// Spotless
+//noinspection GroovyAssignabilityCheck
+project.extensions.add(com.diffplug.blowdryer.Blowdryer, 'Blowdryer', com.diffplug.blowdryer.Blowdryer) // make Blowdryer available in plugin application
+if (enableSpotless.toBoolean()) {
+    apply plugin: 'com.diffplug.spotless'
+
+    // Spotless auto-formatter
+    // See https://github.com/diffplug/spotless/tree/main/plugin-gradle
+    // Can be locally toggled via spotless:off/spotless:on comments
+    spotless {
+        encoding 'UTF-8'
+
+        format 'misc', {
+            target '.gitignore'
+
+            trimTrailingWhitespace()
+            indentWithSpaces(4)
+            endWithNewline()
+        }
+        java {
+            target 'src/main/java/**/*.java', 'src/test/java/**/*.java' // exclude api as they are not our files
+
+            def orderFile = project.file('spotless.importorder')
+            if (!orderFile.exists()) {
+                orderFile = Blowdryer.file('spotless.importorder')
+            }
+            def formatFile = project.file('spotless.eclipseformat.xml')
+            if (!formatFile.exists()) {
+                formatFile = Blowdryer.file('spotless.eclipseformat.xml')
+            }
+
+            toggleOffOn()
+            importOrderFile(orderFile)
+            removeUnusedImports()
+            endWithNewline()
+            //noinspection GroovyAssignabilityCheck
+            eclipse('4.19.0').configFile(formatFile)
         }
     }
 }
 
-if (project.use_eclipse.toBoolean()) {
-    apply {
-        plugin 'java'
-        plugin 'eclipse'
-    }
+// Git submodules
+if (project.file('.git/HEAD').isFile() || project.file('.git').isFile()) {
+    apply plugin: 'com.palantir.git-version'
+}
 
-    eclipse {
-        module {
-            downloadJavadoc = true
-            downloadSources = true
+
+// Configure Java
+
+java {
+    toolchain {
+        if (enableModernJavaSyntax.toBoolean()) {
+            languageVersion.set(JavaLanguageVersion.of(17))
+        } else {
+            languageVersion.set(JavaLanguageVersion.of(8))
         }
+        // Azul covers the most platforms for Java 8+ toolchains, crucially including MacOS arm64
+        vendor.set(JvmVendorSpec.AZUL)
+    }
+    if (!noPublishedSources.toBoolean()) {
+        withSourcesJar()
     }
 }
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+
+    if (enableModernJavaSyntax.toBoolean()) {
+        if (it.name in ['compileMcLauncherJava', 'compilePatchedMcJava']) {
+            return
+        }
+
+        sourceCompatibility = 17
+        options.release.set(8)
+
+        javaCompiler.set(javaToolchains.compilerFor {
+            languageVersion.set(JavaLanguageVersion.of(17))
+            vendor.set(JvmVendorSpec.AZUL)
+        })
+    }
+}
+
+
+// Configure Minecraft
+
+version = modVersion
+group = modGroup
+archivesBaseName = modArchivesBaseName
 
 minecraft {
-    mappings channel: "${mcp_mappings_channel}", version: "${mcp_mappings_version}"
+    mcVersion = minecraftVersion
+    username = developmentEnvironmentUserName.toString()
+    useDependencyAccessTransformers = true
 
-    if (project.has_access_transformer.toBoolean()) {
-        accessTransformer = file('src/main/resources/META-INF/TJCore_at.cfg')
+    // Automatic token injection with RetroFuturaGradle
+    if (gradleTokenModId) {
+        injectedTags.put gradleTokenModId, modId
+    }
+    if (gradleTokenModName) {
+        injectedTags.put gradleTokenModName, modName
+    }
+    if (gradleTokenVersion) {
+        injectedTags.put gradleTokenVersion, modVersion
     }
 
-    runs {
-        client {
-            //noinspection GroovyAssignabilityCheck
-            workingDirectory project.file('run')
-            if (project.use_coremod.toBoolean()) {
-                jvmArg '-Dfml.coreMods.load=' + coremod_plugin_class_name
-            }
-            if (project.use_mixins.toBoolean()) {
-                jvmArg '-Dmixin.hotSwap=true'
-                jvmArg '-Dmixin.checks.interfaces=true'
-                jvmArg '-Dmixin.debug=true'
-            }
-            property 'forge.logging.markers', 'REGISTRIES'
-            property 'forge.logging.console.level', 'debug'
-            environment 'MC_VERSION', minecraft_version.toString()
-        }
+    // JVM arguments
+    extraRunJvmArguments.add("-ea:${modGroup}")
+    if (usesMixins.toBoolean()) {
+        extraRunJvmArguments.addAll([
+            '-Dmixin.hotSwap=true',
+            '-Dmixin.checks.interfaces=true',
+            '-Dmixin.debug.export=true'
+        ])
+    }
+    if (coreModClass) {
+        extraRunJvmArguments.add("-Dfml.coreMods.load=${modGroup}.${coreModClass}")
+    }
+}
 
-        server {
-            //noinspection GroovyAssignabilityCheck
-            workingDirectory project.file('run')
-            if (project.use_coremod.toBoolean()) {
-                jvmArg '-Dfml.coreMods.load=' + coremod_plugin_class_name
-            }
-            if (project.use_mixins.toBoolean()) {
-                jvmArg '-Dmixin.hotSwap=true'
-                jvmArg '-Dmixin.checks.interfaces=true'
-            }
-            property 'forge.logging.markers', 'REGISTRIES'
-            property 'forge.logging.console.level', 'debug'
-            environment 'MC_VERSION', minecraft_version.toString()
+if (generateGradleTokenClass) {
+    tasks.injectTags.outputClassName.set(generateGradleTokenClass)
+}
+
+tasks.named('processIdeaSettings').configure {
+    dependsOn('injectTags')
+}
+
+
+// Allow others using this buildscript to have custom gradle code run
+if (getFile('addon.gradle').exists()) {
+    apply from: 'addon.gradle'
+}
+
+
+// Repositories
+
+// Allow unsafe repos but warn
+repositories.configureEach { repo ->
+    if (repo instanceof UrlArtifactRepository) {
+        if (repo.getUrl() != null && repo.getUrl().getScheme() == "http" && !repo.allowInsecureProtocol) {
+            logger.warn("Deprecated: Allowing insecure connections for repo '${repo.name}' - add 'allowInsecureProtocol = true'")
+            repo.allowInsecureProtocol = true
         }
     }
+}
+
+// Allow adding custom repositories to the buildscript
+if (getFile('repositories.gradle').exists()) {
+    apply from: 'repositories.gradle'
 }
 
 repositories {
-    maven {
-        name 'Cleanroom Maven'
-        url 'https://maven.cleanroommc.com'
+    if (includeWellKnownRepositories.toBoolean()) {
+        exclusiveContent {
+            forRepository {
+                //noinspection ForeignDelegate
+                maven {
+                    name = 'Curse Maven'
+                    url = 'https://www.cursemaven.com'
+                }
+            }
+            filter {
+                includeGroup 'curse.maven'
+            }
+        }
+        exclusiveContent {
+            forRepository {
+                //noinspection ForeignDelegate
+                maven {
+                    name = 'Modrinth'
+                    url = 'https://api.modrinth.com/maven'
+                }
+            }
+            filter {
+                includeGroup 'maven.modrinth'
+            }
+        }
+        maven {
+            name 'Cleanroom Maven'
+            url 'https://maven.cleanroommc.com'
+        }
+        maven {
+            name 'BlameJared Maven'
+            url 'https://maven.blamejared.com'
+        }
     }
-    maven { // JEI
-        name 'Progwml6 Maven'
-        url 'https://dvs1.progwml6.com/files/maven/'
-    }
-    maven { // CraftTweaker and JEI Backup
-        name 'BlameJared Maven'
-        url 'https://maven.blamejared.com'
-    }
-    if (project.use_mixins.toBoolean()) {
+    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
         maven {
             name 'Sponge Maven'
             url 'https://repo.spongepowered.org/maven'
         }
-    }
-    maven {
-        name 'Curse Maven'
-        url 'https://www.cursemaven.com'
-        content {
-            includeGroup 'curse.maven'
+        // need to add this here even if we did not above
+        if (!includeWellKnownRepositories.toBoolean()) {
+            maven {
+                name 'Cleanroom Maven'
+                url 'https://maven.cleanroommc.com'
+            }
         }
     }
+    mavenLocal() // Must be last for caching to work
+}
+
+
+// Dependencies
+
+// Configure dependency configurations
+configurations {
+    embed
+    implementation.extendsFrom(embed)
 }
 
 dependencies {
-    implementation 'org.jetbrains:annotations:23.0.0'
-    minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
-
-    // Hard Dependencies
-    // the CCL deobf jar uses very old MCP mappings, making it error at runtime in runClient/runServer
-    // therefore we manually deobf the regular jar
-    implementation fg.deobf("curse.maven:codechicken-lib-1-8-${ccl_pid}:${ccl_fid}")
-    implementation fg.deobf("curse.maven:gregtech-ce-unofficial-${ceu_pid}:${ceu_fid}")
-    //implementation (files("libs/gregtech-1.12.2-${project.gregtech_version}-deobf.jar"))
-    implementation fg.deobf("curse.maven:gregicality-multiblocks-${gcym_pid}:${gcym_fid}")
-
-    // Soft Dependencies
-    implementation "mezz.jei:jei_1.12.2:${project.jei_version}"
-    implementation "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-${project.crt_version}"
-    implementation fg.deobf("curse.maven:top-${top_pid}:${top_fid}")
-    implementation fg.deobf("curse.maven:ctm-${ctm_pid}:${ctm_fid}")
-    implementation fg.deobf("curse.maven:groovyscript-${grs_pid}:${grs_fid}")
-    implementation fg.deobf("curse.maven:ae2-extended-life-${ae2_pid}:${ae2_fid}")
-
-    // Draconic Evolution and dependencies
-    implementation fg.deobf("curse.maven:draconic_evolution-${drac_pid}:${drac_fid}")
-    implementation fg.deobf("curse.maven:brandons_core-${bran_pid}:${bran_fid}")
-    implementation fg.deobf("curse.maven:redstone_flux-${rf_pid}:${rf_fid}")
-
-    annotationProcessor "org.jetbrains:annotations:${annotations_version}"
-
-
-    // Tests
-    //testImplementation("org.junit.jupiter:junit-jupiter:${junit_version}")
-    //testImplementation("org.hamcrest:hamcrest:${hamcrest_version}")
-
-    if (project.use_mixins.toBoolean()) {
-        compileOnly "zone.rong:mixinbooter:${mixinbooter_version}"
-        runtimeOnly "zone.rong:mixinbooter:${mixinbooter_version}"
-
-        annotationProcessor "org.spongepowered:mixin:${mixin_annotations_version}:processor"
-    } else {
-        // GroovyScript dependency
-        // remove this if project.use_mixins is true
-        runtimeOnly "zone.rong:mixinbooter:${mixinbooter_version}"
-
-    }
-}
-
-fancyGradle {
-    patches {
-        resources
-        coremods
-        asm
-        codeChickenLib
-    }
-}
-
-processJarTask jar
-
-if (project.build_deobfJar.toBoolean()) {
-    // Create deobf dev jars
-    tasks.register('deobfJar', Jar) {
-        archiveClassifier.set 'deobf'
-        from sourceSets.main.output
-    }
-    processJarTask deobfJar
-}
-
-if (project.build_apiJar.toBoolean()) {
-    // Create API library jar
-    tasks.register('apiJar', Jar) {
-        archiveClassifier.set 'api'
-        from(sourceSets.main.java) {
-            include 'TJCore/api/**'
+    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
+        implementation 'zone.rong:mixinbooter:7.0'
+        api('org.spongepowered:mixin:0.8.3') {
+            transitive = false
+        }
+        annotationProcessor('org.spongepowered:mixin:0.8.3') {
+            transitive = false
         }
 
-        from(sourceSets.main.output) {
-            include 'TJCore/api/**'
+        annotationProcessor 'org.ow2.asm:asm-debug-all:5.2'
+        // should use 24.1.1 but 30.0+ has a vulnerability fix
+        annotationProcessor 'com.google.guava:guava:30.0-jre'
+        // should use 2.8.6 but 2.8.9+ has a vulnerability fix
+        annotationProcessor 'com.google.code.gson:gson:2.8.9'
+    }
+
+    if (enableJUnit.toBoolean()) {
+        testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
+        testImplementation 'org.hamcrest:hamcrest:2.2'
+    }
+
+    if (enableModernJavaSyntax.toBoolean()) {
+        annotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.0'
+        compileOnly('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
+            transitive = false
         }
+        // workaround for https://github.com/bsideup/jabel/issues/174
+        annotationProcessor 'net.java.dev.jna:jna-platform:5.13.0'
+        // Allow jdk.unsupported classes like sun.misc.Unsafe, workaround for JDK-8206937 and fixes Forge crashes in tests.
+        patchedMinecraft 'me.eigenraven.java8unsupported:java-8-unsupported-shim:1.0.0'
+
+        // allow Jabel to work in tests
+        testAnnotationProcessor "com.github.bsideup.jabel:jabel-javac-plugin:1.0.0"
+        testCompileOnly("com.github.bsideup.jabel:jabel-javac-plugin:1.0.0") {
+            transitive = false // We only care about the 1 annotation class
+        }
+        testCompileOnly "me.eigenraven.java8unsupported:java-8-unsupported-shim:1.0.0"
     }
+
+    compileOnlyApi 'org.jetbrains:annotations:23.0.0'
+    annotationProcessor 'org.jetbrains:annotations:23.0.0'
 }
 
-if (project.build_sourceJar.toBoolean()) {
-    // Create source jar
-    tasks.register('sourcesJar', Jar) {
-        archiveClassifier.set 'sources'
-        from sourceSets.main.allJava
-    }
+if (getFile('dependencies.gradle').exists()) {
+    apply from: 'dependencies.gradle'
 }
 
-// Loading resources, works even on IDE client runs
+
+// Test configuration
+
+// Ensure tests have access to minecraft classes
 sourceSets {
-    main {
-        if (project.use_mixins.toBoolean()) {
-            ext.refMap = 'mixins.' + archives_base_name + '.refmap.json'
-        }
-
-        java {
-            srcDirs = ['src/main/java', 'src/api/java']
-        }
-
-        resources {
-            srcDirs = ['src/main/resources']
-        }
-    }
-
     test {
         java {
-            srcDirs = ['src/test/java']
+            compileClasspath += patchedMc.output + mcLauncher.output
+            runtimeClasspath += patchedMc.output + mcLauncher.output
         }
-        resources {
-            srcDirs = ['src/test/resources']
-        }
-    }
-
-    // at compile time, put resources in same directories as classes
-    main.output.setResourcesDir(main.java.classesDirectory)
-}
-
-artifacts {
-    if (project.build_deobfJar.toBoolean()) {
-        archives deobfJar
-    }
-    if (project.build_apiJar.toBoolean()) {
-        archives apiJar
-    }
-    if (project.build_sourceJar.toBoolean()) {
-        archives sourcesJar
-    }
-}
-
-// It is important to NOT re-obfuscate jars for the deobfuscated environment.
-// Therefore, we do not finalize the 'jar' task with the 'reobfJar' task.
-// The Forge FG5 example buildscript states otherwise, however it creates broken builds in deobfuscated environments.
-
-processResources {
-    // required to allow file expansion later
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
-
-    // this will ensure that this task is redone when the versions change.
-    inputs.property 'version', version
-    inputs.property 'mcversion', minecraft_version
-
-    // replace stuff in mcmod.info, nothing else
-    from(sourceSets.main.resources.srcDirs) {
-        include 'mcmod.info'
-
-        // replace version and mcversion
-        expand(['version': version, 'mcversion': minecraft_version])
-    }
-
-    // copy everything else except mcmod.info
-    from(sourceSets.main.resources.srcDirs) {
-        exclude 'mcmod.info'
     }
 }
 
 test {
+    // ensure tests are run with java8
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(8)
+    }.get()
+
     testLogging {
         events TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.FAILED
         exceptionFormat TestExceptionFormat.FULL
@@ -291,38 +412,415 @@ test {
         showStandardStreams true
     }
 
-    useJUnitPlatform()
+    if (enableJUnit.toBoolean()) {
+        useJUnitPlatform()
+    }
 }
 
-/**
- * Applies required processing to jar tasks
- * @param task the task to process
- */
-private void processJarTask(task) {
-    task.configure {
-        manifest {
-            // noinspection GroovyAssignabilityCheck
-            def attribute_map = [:]
-            if (project.use_coremod.toBoolean()) {
-                attribute_map['FMLCorePlugin'] = project.coremod_plugin_class_name
-                if (project.include_mod.toBoolean()) {
-                    attribute_map['FMLCorePluginContainsFMLMod'] = true
-                    attribute_map['ForceLoadAsMod'] = project.gradle.startParameter.taskNames[0] == 'build'
-                }
-            }
-            if (project.use_mixins.toBoolean()) {
-                attribute_map['TweakClass'] = 'org.spongepowered.asm.launch.MixinTweaker'
-            }
-            if (project.has_access_transformer.toBoolean()) {
-                attribute_map['FMLAT'] = 'TJCore_at.cfg'
-            }
-            attributes(attribute_map)
-        }
 
-        // exclude all files in src/api from being shipped in the jar
-        // this prevents crashes in obfuscated environments
-        file('src/api/').eachDirRecurse { dir ->
-            exclude dir.name
+// Resource processing and jar building
+
+processResources {
+    // this will ensure that this task is redone when the versions change.
+    inputs.property 'version', modVersion
+    inputs.property 'mcversion', minecraftVersion
+    // Blowdryer puts these files into the resource directory, so
+    // exclude them from builds (doesn't hurt to exclude even if not present)
+    exclude('spotless.importorder')
+    exclude('spotless.eclipseformat.xml')
+
+    // replace stuff in mcmod.info, nothing else
+    filesMatching(['mcmod.info', 'pack.mcmeta']) { fcd ->
+        // replace version and mcversion
+        fcd.expand(
+                'version': modVersion,
+                'mcversion': minecraftVersion
+        )
+    }
+}
+
+// Automatically generate a mixin json file if it does not already exist
+tasks.register('generateAssets') {
+    group = 'GT Buildscript'
+    description = 'Generates a mixin config file at /src/main/resources/mixins.modid.json if needed'
+    onlyIf {
+        usesMixins.toBoolean()
+    }
+    doLast {
+        def mixinConfigFile = getFile("src/main/resources/mixins.${modId}.json")
+        if (!mixinConfigFile.exists()) {
+            def mixinConfigRefmap = "mixins.${modId}.refmap.json"
+
+            mixinConfigFile.text = """{
+  "package": "${modGroup}.${mixinsPackage}",
+  "refmap": "${mixinConfigRefmap}",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "client": [],
+  "server": []
+}
+"""
         }
     }
+}
+
+if (usesMixins.toBoolean()) {
+    tasks.named('processResources').configure {
+        dependsOn('generateAssets')
+    }
+}
+
+jar {
+    manifest {
+        def attribute_map = [:]
+        if (coreModClass) {
+            attribute_map['FMLCorePlugin'] = "${modGroup}.${coreModClass}"
+        }
+        if (!containsMixinsAndOrCoreModOnly.toBoolean() && (usesMixins.toBoolean() || coreModClass)) {
+            attribute_map['FMLCorePluginContainsFMLMod'] = true
+        }
+        if (accessTransformersFile) {
+            attribute_map['FMLAT'] = accessTransformersFile.toString()
+        }
+
+        if (usesMixins.toBoolean()) {
+            attribute_map['ForceLoadAsMod'] = !containsMixinsAndOrCoreModOnly.toBoolean()
+        }
+        attributes(attribute_map)
+    }
+
+    // Add all embedded dependencies into the jar
+    from provider {
+        configurations.embed.collect {
+            it.isDirectory() ? it : zipTree(it)
+        }
+    }
+}
+
+// Create API library jar
+tasks.register('apiJar', Jar) {
+    archiveClassifier.set 'api'
+    from(sourceSets.main.java) {
+        include "${modGroupPath}/${apiPackagePath}/**"
+    }
+
+    from(sourceSets.main.output) {
+        include "${modGroupPath}/${apiPackagePath}/**"
+    }
+}
+
+
+// IDE Configuration
+
+eclipse {
+    classpath {
+        downloadSources = true
+        downloadJavadoc = true
+    }
+}
+
+idea {
+    module {
+        inheritOutputDirs true
+        downloadJavadoc true
+        downloadSources true
+    }
+    project {
+        settings {
+            runConfigurations {
+                '1. Run Client'(Gradle) {
+                    taskNames = ['runClient']
+                }
+                '2. Run Server'(Gradle) {
+                    taskNames = ['runServer']
+                }
+                '3. Run Obfuscated Client'(Gradle) {
+                    taskNames = ['runObfClient']
+                }
+                '4. Run Obfuscated Server'(Gradle) {
+                    taskNames = ['runObfServer']
+                }
+                if (enableSpotless.toBoolean()) {
+                    "5. Apply Spotless"(Gradle) {
+                        taskNames = ["spotlessApply"]
+                    }
+                }
+                'Update Buildscript'(Gradle) {
+                    taskNames = ['updateBuildScript']
+                }
+                'FAQ'(Gradle) {
+                    taskNames = ['faq']
+                }
+            }
+            compiler.javac {
+                afterEvaluate {
+                    javacAdditionalOptions = '-encoding utf8'
+                    moduleJavacAdditionalOptions = [
+                            (project.name + '.main'): tasks.compileJava.options.compilerArgs.collect {
+                                '"' + it + '"'
+                            }.join(' ')
+                    ]
+                }
+            }
+        }
+    }
+}
+
+
+// Deployment
+
+final boolean isCIEnv = providers.environmentVariable('CI').getOrElse('false').toBoolean()
+def final changelogEnv = providers.environmentVariable('CHANGELOG_LOCATION')
+File changelogFile = new File(changelogEnv.getOrElse('CHANGELOG.md'))
+
+if (isCIEnv || deploymentDebug.toBoolean()) {
+    artifacts {
+        if (!noPublishedSources.toBoolean()) {
+            archives sourcesJar
+        }
+        if (apiPackage) {
+            archives apiJar
+        }
+    }
+}
+
+// Curseforge
+def final cfApiKey = providers.environmentVariable('CURSEFORGE_API_KEY')
+if (cfApiKey.isPresent() || deploymentDebug.toBoolean()) {
+    apply plugin: 'net.darkhax.curseforgegradle'
+    //noinspection UnnecessaryQualifiedReference
+    tasks.register('curseforge', net.darkhax.curseforgegradle.TaskPublishCurseForge) {
+        apiToken = cfApiKey.get()
+        def projectIdVar = providers.environmentVariable('CURSEFORGE_PROJECT_ID')
+
+        def mainFile = upload(projectIdVar.getOrElse(curseForgeProjectId), reobfJar)
+        def changelogRaw = changelogFile.exists() ? changelogFile.getText('UTF-8') : ""
+
+        mainFile.releaseType = getReleaseType()
+        mainFile.changelog = changelogRaw
+        mainFile.changelogType = 'markdown'
+        mainFile.addModLoader 'Forge'
+        mainFile.addJavaVersion "Java 8"
+        mainFile.addGameVersion minecraftVersion
+
+        if (curseForgeRelations.size() != 0) {
+            String[] deps = curseForgeRelations.split(';')
+            deps.each { dep ->
+                if (dep.size() == 0) {
+                    return
+                }
+                String parts = dep.split(':')
+                String type = parts[0], slug = parts[1]
+                if(!(type in ['requiredDependency', 'embeddedLibrary', 'optionalDependency', 'tool', 'incompatible'])) {
+                    throw new Exception('Invalid Curseforge dependency type: ' + type)
+                }
+                mainFile.addRelation(slug, type)
+            }
+        }
+
+        for (artifact in getSecondaryArtifacts()) {
+            def additionalFile = mainFile.withAdditionalFile(artifact)
+            additionalFile.changelog = changelogRaw
+        }
+        disableVersionDetection()
+        debugMode = deploymentDebug.toBoolean()
+    }
+    tasks.curseforge.dependsOn(build)
+}
+
+// Modrinth
+def final modrinthApiKey = providers.environmentVariable('MODRINTH_API_KEY')
+if (modrinthApiKey.isPresent() || deploymentDebug.toBoolean()) {
+    apply plugin: 'com.modrinth.minotaur'
+    def final projectIdVar = providers.environmentVariable('MODRINTH_PROJECT_ID')
+
+    modrinth {
+        token = modrinthApiKey.get()
+        projectId = projectIdVar.getOrElse(modrinthProjectId)
+        changelog = changelogFile.exists() ? changelogFile.getText('UTF-8') : ""
+        versionType = getReleaseType()
+        versionNumber = modVersion
+        gameVersions = [minecraftVersion]
+        loaders = ["forge"]
+        debugMode = deploymentDebug.toBoolean()
+        uploadFile = file("build/libs/${archivesBaseName}-${version}.jar")
+        additionalFiles = getSecondaryArtifacts()
+    }
+    if (modrinthRelations.size() != 0) {
+        String[] deps = modrinthRelations.split(';')
+        deps.each { dep ->
+            if (dep.size() == 0) {
+                return
+            }
+            String[] parts = dep.split(':')
+            String qual = parts[0].split('-')
+            addModrinthDep(qual[0], qual[1], parts[1])
+        }
+    }
+    tasks.modrinth.dependsOn(build)
+}
+
+def addModrinthDep(String scope, String type, String name) {
+    com.modrinth.minotaur.dependencies.Dependency dep
+    if (!(scope in ['required', 'optional', 'incompatible', 'embedded'])) {
+        throw new Exception('Invalid modrinth dependency scope: ' + scope)
+    }
+    switch (type) {
+        case 'project':
+            dep = new ModDependency(name, scope)
+            break
+        case 'version':
+            dep = new VersionDependency(name, scope)
+            break
+        default:
+            throw new Exception('Invalid modrinth dependency type: ' + type)
+    }
+    project.modrinth.dependencies.add(dep)
+}
+
+
+// Buildscript updating
+
+def buildscriptGradleVersion = '8.1.1'
+
+tasks.named('wrapper', Wrapper).configure {
+    gradleVersion = buildscriptGradleVersion
+}
+
+tasks.register('updateBuildScript') {
+    group = 'GT Buildscript'
+    description = 'Updates the build script to the latest version'
+
+    if (gradle.gradleVersion != buildscriptGradleVersion && !Boolean.getBoolean('DISABLE_BUILDSCRIPT_GRADLE_UPDATE')) {
+        dependsOn('wrapper')
+    }
+
+    doLast {
+        if (performBuildScriptUpdate()) return
+        print('Build script already up to date!')
+    }
+}
+
+if (!project.getGradle().startParameter.isOffline() && !Boolean.getBoolean('DISABLE_BUILDSCRIPT_UPDATE_CHECK') && isNewBuildScriptVersionAvailable()) {
+    if (autoUpdateBuildScript.toBoolean()) {
+        performBuildScriptUpdate()
+    } else {
+        out.style(Style.SuccessHeader).println("Build script update available! Run 'gradle updateBuildScript'")
+        if (gradle.gradleVersion != buildscriptGradleVersion) {
+            out.style(Style.SuccessHeader).println("updateBuildScript can update gradle from ${gradle.gradleVersion} to ${buildscriptGradleVersion}\n")
+        }
+    }
+}
+
+static URL availableBuildScriptUrl() {
+    new URL("https://raw.githubusercontent.com/GregTechCEu/Buildscripts/master/build.gradle")
+}
+
+static URL exampleSettingsGradleUrl() {
+    new URL("https://raw.githubusercontent.com/GregTechCEu/Buildscripts/master/settings.gradle")
+}
+
+boolean verifySettingsGradle() {
+    def settingsFile = getFile("settings.gradle")
+    if (!settingsFile.exists()) {
+        println("Downloading default settings.gradle")
+        exampleSettingsGradleUrl().withInputStream { i -> settingsFile.withOutputStream { it << i } }
+        return true
+    }
+    return false
+}
+
+boolean performBuildScriptUpdate() {
+    if (isNewBuildScriptVersionAvailable()) {
+        def buildscriptFile = getFile("build.gradle")
+        availableBuildScriptUrl().withInputStream { i -> buildscriptFile.withOutputStream { it << i } }
+        def out = services.get(StyledTextOutputFactory).create('buildscript-update-output')
+        out.style(Style.Success).print("Build script updated. Please REIMPORT the project or RESTART your IDE!")
+        if (verifySettingsGradle()) {
+            throw new GradleException("Settings has been updated, please re-run task.")
+        }
+        return true
+    }
+    return false
+}
+
+boolean isNewBuildScriptVersionAvailable() {
+    Map parameters = ["connectTimeout": 10000, "readTimeout": 10000]
+
+    String currentBuildScript = getFile("build.gradle").getText()
+    String currentBuildScriptHash = getVersionHash(currentBuildScript)
+    String availableBuildScript = availableBuildScriptUrl().newInputStream(parameters).getText()
+    String availableBuildScriptHash = getVersionHash(availableBuildScript)
+
+    boolean isUpToDate = currentBuildScriptHash.empty || availableBuildScriptHash.empty || currentBuildScriptHash == availableBuildScriptHash
+    return !isUpToDate
+}
+
+static String getVersionHash(String buildScriptContent) {
+    String versionLine = buildScriptContent.find("^//version: [a-z0-9]*")
+    if (versionLine != null) {
+        return versionLine.split(": ").last()
+    }
+    return ""
+}
+
+
+// Faq
+
+tasks.register('faq') {
+    group = 'GT Buildscript'
+    description = 'Prints frequently asked questions about building a project'
+    doLast {
+        print("To update this buildscript to the latest version, run 'gradlew updateBuildScript' or run the generated run configuration if you are using IDEA.\n" +
+            "To add new dependencies to your project, place them in 'dependencies.gradle', NOT in 'build.gradle' as they would be replaced when the script updates.\n" +
+            "To add new repositories to your project, place them in 'repositories.gradle'.\n" +
+            "If you need additional gradle code to run, you can place it in a file named 'addon.gradle' (or either of the above, up to you for organization).\n" +
+            "If your build fails to recognize the syntax of newer Java versions, enable Jabel in your 'gradle.properties' under the option name 'enableModernJavaSyntax'.\n" +
+            "Report any issues or feature requests you have for this build script to https://github.com/GregTechCEu/Buildscripts")
+    }
+}
+
+
+// Helpers
+
+def getFile(String relativePath) {
+    return new File(projectDir, relativePath)
+}
+
+def checkPropertyExists(String propertyName) {
+    if (!project.hasProperty(propertyName)) {
+        throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"gradle.properties\". You can find all properties and their description here: https://github.com/GregTechCEu/Buildscripts/blob/main/gradle.properties")
+    }
+}
+
+def propertyDefaultIfUnset(String propertyName, defaultValue) {
+    if (!project.hasProperty(propertyName) || project.property(propertyName) == "") {
+        project.ext.setProperty(propertyName, defaultValue)
+    }
+}
+
+def propertyDefaultIfUnsetWithEnvVar(String propertyName, defaultValue, String envVarName) {
+    def envVar = providers.environmentVariable(envVarName)
+    if (envVar.isPresent()) {
+        project.ext.setProperty(propertyName, envVar.get())
+    } else {
+        propertyDefaultIfUnset(propertyName, defaultValue)
+    }
+}
+
+def getSecondaryArtifacts() {
+    def secondaryArtifacts = [jar]
+    if (!noPublishedSources.toBoolean()) secondaryArtifacts += [sourcesJar]
+    if (apiPackage) secondaryArtifacts += [apiJar]
+    return secondaryArtifacts
+}
+
+def getReleaseType() {
+    String type = releaseType
+    if (!(type in ['release', 'beta', 'alpha'])) {
+        throw new Exception("Release type invalid! Found \"" + type + "\", allowed: \"release\", \"beta\", \"alpha\"")
+    }
+    return type
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,46 @@
+//file:noinspection DependencyNotationArgument
+// TODO remove when fixed in RFG ^
+/*
+ * Add your dependencies here. Common configurations:
+ *  - implementation("group:name:version:classifier"): if you need this for internal implementation details of the mod.
+ *       Available at compiletime and runtime for your environment.
+ *
+ *  - compileOnlyApi("g:n:v:c"): if you need this for internal implementation details of the mod.
+ *       Available at compiletime but not runtime for your environment.
+ *
+ *  - annotationProcessor("g:n:v:c"): mostly for java compiler plugins, if you know you need this, use it, otherwise don't worry
+ *
+ *  - testCONFIG("g:n:v:c"): replace CONFIG by one of the above, same as above but for the test sources instead of main
+ *
+ * You can exclude transitive dependencies (dependencies of the chosen dependency) by appending { transitive = false } if needed.
+ *
+ * To add a mod with CurseMaven, replace '("g:n:v:c")' in the above with 'rfg.deobf("curse.maven:project_slug-project_id:file_id")'
+ * Example: implementation rfg.deobf("curse.maven:gregtech-ce-unofficial-557242:4527757")
+ *
+ * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
+ */
+dependencies {
+
+    // Hard Dependencies
+
+    // the CCL deobf jar uses very old MCP mappings, making it error at runtime in runClient/runServer
+    // therefore we manually deobf the regular jar
+    implementation rfg.deobf('curse.maven:codechicken-lib-1-8-242818:2779848') // CCL 3.2.3.358
+    implementation rfg.deobf('curse.maven:gregtech-ce-unofficial-557242:4527757') // GTCEu 2.6.2-beta
+    //implementation (files('libs/gregtech-1.12.2-2.6.2-beta-deobf.jar'))
+    implementation rfg.deobf("curse.maven:gregicality-multiblocks-564858:4529101") // GCYM 
+
+    // Soft Dependencies
+
+    implementation 'mezz.jei:jei_1.12.2:4.16.1.302'
+    implementation 'CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.684'
+    implementation rfg.deobf("curse.maven:top-245211:2667280")
+    implementation rfg.deobf("curse.maven:ctm-267602:2915363")
+    implementation rfg.deobf("curse.maven:groovyscript-687577:4399621")
+    implementation rfg.deobf("curse.maven:ae2-extended-life-570458:4402048")
+
+    // Draconic Evolution and dependencies
+    implementation rfg.deobf("curse.maven:draconic_evolution-223565:3431261")
+    implementation rfg.deobf("curse.maven:brandons_core-231382:3408276")
+    implementation rfg.deobf("curse.maven:redstone_flux-270789:2920436")
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,78 +1,123 @@
+modName = TJCore
+
+# This is a case-sensitive string to identify your mod. Convention is to use lower case.
+modId = tjcore
+
+modGroup = tjcore
+
+modVersion = 0.1.3
+
+# The name of your jar when you produce builds, not including any versioning info
+modArchivesBaseName = TJCore
+
+# Will update your build.gradle automatically whenever an update is available
+autoUpdateBuildScript = false
+
+minecraftVersion = 1.12.2
+
+# Select a username for testing your mod with breakpoints. You may leave this empty for a random username each time you
+# restart Minecraft in development. Choose this dependent on your mod:
+# Do you need consistent player progressing (for example Thaumcraft)? -> Select a name
+# Do you need to test how your custom blocks interacts with a player that is not the owner? -> leave name empty
+# Alternatively this can be set with the 'DEV_USERNAME' environment variable.
+developmentEnvironmentUserName = Developer
+
+# Enables using modern java syntax (up to version 17) via Jabel, while still targeting JVM 8.
+# See https://github.com/bsideup/jabel for details on how this works.
+# Using this requires that you use a Java 17 JDK for development.
+enableModernJavaSyntax = true
+
+# Generate a class with String fields for the mod id, name and version named with the fields below
+generateGradleTokenClass = tjcore.Tags
+gradleTokenModId = MODID
+gradleTokenModName = MODNAME
+gradleTokenVersion = VERSION
+
+# In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
+# leave this property empty.
+# Example value: apiPackage = api + modGroup = com.myname.mymodid -> com.myname.mymodid.api
+apiPackage =
+
+# Specify the configuration file for Forge's access transformers here. It must be placed into /src/main/resources/
+# There can be multiple files in a comma-separated list.
+# Example value: mymodid_at.cfg,jei_at.cfg
+accessTransformersFile =
+
+# Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
+usesMixins = false
+# Specify the package that contains all of your Mixins. You may only place Mixins in this package or the build will fail!
+mixinsPackage =
+# Specify the core mod entry class if you use a core mod. This class must implement IFMLLoadingPlugin!
+# Example value: coreModClass = asm.FMLPlugin + modGroup = com.myname.mymodid -> com.myname.mymodid.asm.FMLPlugin
+coreModClass =
+# If your project is only a consolidation of mixins or a core mod and does NOT contain a 'normal' mod (meaning that
+# there is no class annotated with @Mod) you want this to be true. When in doubt: leave it on false!
+containsMixinsAndOrCoreModOnly = false
+
+# Enables Mixins even if this mod doesn't use them, useful if one of the dependencies uses mixins.
+forceEnableMixins = true
+
+# Adds CurseMaven, Modrinth Maven, BlameJared maven, and some more well-known 1.12.2 repositories
+includeWellKnownRepositories = true
+
+
+# Publishing to modrinth requires you to set the MODRINTH_API_KEY environment variable to your current modrinth API token.
+
+# The project's ID on Modrinth. Can be either the slug or the ID.
+# Leave this empty if you don't want to publish on Modrinth.
+# Alternatively this can be set with the 'MODRINTH_PROJECT_ID' environment variable.
+modrinthProjectId =
+
+# The project's relations on Modrinth. You can use this to refer to other projects on Modrinth.
+# Syntax: scope1-type1:name1;scope2-type2:name2;...
+# Where scope can be one of [required, optional, incompatible, embedded],
+#       type can be one of [project, version],
+#       and the name is the Modrinth project or version slug/id of the other mod.
+# Example: required-project:jei;optional-project:top;incompatible-project:gregtech
+modrinthRelations =
+
+
+# Publishing to CurseForge requires you to set the CURSEFORGE_API_KEY environment variable to one of your CurseForge API tokens.
+
+# The project's numeric ID on CurseForge. You can find this in the About Project box.
+# Leave this empty if you don't want to publish on CurseForge.
+# Alternatively this can be set with the 'CURSEFORGE_PROJECT_ID' environment variable.
+curseForgeProjectId =
+
+# The project's relations on CurseForge. You can use this to refer to other projects on CurseForge.
+# Syntax: type1:name1;type2:name2;...
+# Where type can be one of [requiredDependency, embeddedLibrary, optionalDependency, tool, incompatible],
+#       and the name is the CurseForge project slug of the other mod.
+# Example: requiredDependency:railcraft;embeddedLibrary:cofhlib;incompatible:buildcraft
+curseForgeRelations =
+
+# This project's release type on CurseForge and/or Modrinth
+# Allowed types: release, beta, alpha
+releaseType = release
+
+# Prevent the source code from being published
+noPublishedSources = false
+
+# Enable spotless checks
+# Enforces code formatting on your source code
+# By default this will use the files found here: https://github.com/GregTechCEu/Buildscripts/tree/master/spotless
+# to format your code. However, you can create your own version of these files and place them in your project's
+# root directory to apply your own formatting options instead.
+enableSpotless = false
+
+# Enable JUnit testing platform used for testing your code.
+# Uses JUnit 5. See guide and documentation here: https://junit.org/junit5/docs/current/user-guide/
+enableJUnit = false
+
+# Deployment debug setting
+# Uncomment this to test deployments to CurseForge and Modrinth
+# Alternatively, you can set the 'DEPLOYMENT_DEBUG' environment variable.
+deploymentDebug = false
+
+
+# Gradle Settings
+# Effectively applies the '--stacktrace' flag by default
+org.gradle.logging.stacktrace = all
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs = -Xmx3G
-org.gradle.daemon = false
-
-# Mod Information
-minecraft_version = 1.12.2
-maven_group = TJCore
-archives_base_name = tjcore
-version=0.1.3
-
-# This will downlaod sourses and Javadoc for the dependencies (for example mixins), set which ide you use
-# You can look up dependencies and their available sources and Javadoc in intellij by going to File ProjectStructure Libaries
-use_intellij_idea = true
-use_eclipse = false
-
-# Optional Jar compiling
-build_deobfJar = false
-build_apiJar = false
-build_sourceJar = false
-
-# If any properties change below this line, refresh gradle again to ensure everything is working correctly.
-
-# Boilerplate Options
-# mixins are enabled for GroovyScript to work in dev
-use_mixins = false
-use_coremod = false
-has_access_transformer = false
-
-# Coremod Arguments
-include_mod = false
-coremod_plugin_class_name =
-
-# Project Dependencies
-
-## Gradle Plugins
-forge_gradle_version = 5.1.+
-fancy_gradle_version = 1.1.+
-
-## Minecraft-Specific
-forge_version = 14.23.5.2860
-mcp_mappings_channel = stable
-mcp_mappings_version = 39-1.12
-
-## Hard Dependencies
-ccl_pid = 242818
-ccl_fid = 2779848
-ceu_pid = 557242
-ceu_fid = 4527757
-gregtech_version = 2.6.2-beta
-gcym_pid = 564858
-gcym_fid = 4529101
-
-## Soft Dependencies
-jei_version = 4.16.1.302
-crt_version = 4.1.20.684
-top_pid = 245211
-top_fid = 2667280
-ctm_pid = 267602
-ctm_fid = 2915363
-grs_pid = 687577
-grs_fid = 4399621
-ae2_pid = 570458
-ae2_fid = 4402048
-drac_pid = 223565
-drac_fid = 3431261
-bran_pid = 231382
-bran_fid = 3408276
-rf_pid = 270789
-rf_fid = 2920436
-
-## Mixin Depdencies
-mixingradle_version = 0.7-SNAPSHOT
-mixinbooter_version = 7.0
-mixin_annotations_version = 0.8.5
-
-## Annotations
-annotations_version = 23.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,13 +1,33 @@
 pluginManagement {
     repositories {
+        maven {
+            // RetroFuturaGradle
+            name 'GTNH Maven'
+            //noinspection HttpUrlsUsage
+            url 'http://jenkins.usrv.eu:8081/nexus/content/groups/public/'
+            allowInsecureProtocol = true
+            //noinspection GroovyAssignabilityCheck
+            mavenContent {
+                includeGroup 'com.gtnewhorizons'
+                includeGroup 'com.gtnewhorizons.retrofuturagradle'
+            }
+        }
         gradlePluginPortal()
-        maven {
-            name 'FancyGradle Maven'
-            url 'https://gitlab.com/api/v4/projects/26758973/packages/maven'
-        }
-        maven {
-            name 'ForgeGradle Maven'
-            url 'https://maven.minecraftforge.net'
-        }
+        mavenCentral()
+        mavenLocal()
     }
 }
+
+plugins {
+    id 'com.diffplug.blowdryerSetup' version '1.6.0'
+    // Automatic toolchain provisioning
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
+}
+
+blowdryerSetup {
+    repoSubfolder 'spotless'
+    github('GregTechCEu/Buildscripts', 'commit', 'a1e1f2dfebb66f8fc652cd3e020b871fbd8604cb')
+    //devLocal '.' // Use this when testing config updates locally
+}
+
+rootProject.name = modArchivesBaseName

--- a/src/main/java/tjcore/TJValues.java
+++ b/src/main/java/tjcore/TJValues.java
@@ -1,8 +1,8 @@
 package tjcore;
 
 public class TJValues {
-    public static final String MODID = "tjcore";
+    public static final String MODID = Tags.MODID;
 
-    public static final String VERSION = "@VERSION@";
+    public static final String VERSION = Tags.VERSION;
     public static final int[][] adjacentIntArr = new int[][] {{1,0,0}, {-1,0,0}, {0,1,0}, {0,-1,0}, {0,0,1}, {0,0,-1}};
 }


### PR DESCRIPTION
`build.gradle` should not ever be touched after this PR, aside from running the `updateBuildScript` gradle task when there are updates available. Instead any new dependencies should go in `dependencies.gradle` as well as modifying some fields in `gradle.properties` if new things get added (like Access Transformer, Coremod, Mixins, etc).

Additionally I enabled the modern java syntax option, meaning that you will need a Java 17 JDK for TJCore development. This is as easy as going to `File > Project Structure > Project` and changing the SDK value to some Java 17 JDK (I recomment `zulu-17`, but the choice is yours)